### PR TITLE
Adding DPI parameter to PDF tests and print test result as a method

### DIFF
--- a/src/lib/java/PDFTest.java
+++ b/src/lib/java/PDFTest.java
@@ -14,7 +14,11 @@ public class PDFTest extends Test {
     private static final Pattern pattern = Patterns.PDF;
     private float dpi_;
     protected PDFTest(File file, String appname) {
+        this(file, appname, 300f);
+    }
+    protected PDFTest(File file, String appname, float dpi) {
         super(file, appname);
+        this.dpi_=dpi;
     }
 
     @Override

--- a/src/lib/java/PDFTest.java
+++ b/src/lib/java/PDFTest.java
@@ -2,10 +2,7 @@ import com.applitools.eyes.Eyes;
 import com.applitools.eyes.TestResults;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -15,37 +12,33 @@ import java.util.regex.Pattern;
  */
 public class PDFTest extends Test {
     private static final Pattern pattern = Patterns.PDF;
-
+    private float dpi_;
     protected PDFTest(File file, String appname) {
         super(file, appname);
     }
 
     @Override
     public void run(Eyes eyes) {
-        String res = null;
         Exception ex = null;
+        TestResults result=null;
 
         try {
             PDDocument document = PDDocument.load(file_);
             PDFRenderer pdfRenderer = new PDFRenderer(document);
-
             eyes.open(appname_, name());
 
             for (int page = 0; page < document.getNumberOfPages(); ++page) {
-//                BufferedImage bim = pdfRenderer.renderImage(page);
-                BufferedImage bim = pdfRenderer.renderImageWithDPI(page, 300f);
-                ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                ImageIO.write(bim, "png", stream);
-                eyes.checkImage(stream.toByteArray(), String.format("Page-%s", page));
+                BufferedImage bim = pdfRenderer.renderImageWithDPI(page, dpi_);
+                eyes.checkImage(bim, String.format("Page-%s", page));
             }
-            TestResults result = eyes.close(false);
-            res = result.isNew() ? "New" : (result.isPassed() ? "Passed" : "Failed");
+            result = eyes.close(false);
+            printTestResults(result);
             document.close();
         } catch (IOException e) {
-            res = "Error";
             ex = e;
+            System.out.printf("Error closing test %s \nPath: %s \nReason: %s \n",e.getMessage());
+
         } finally {
-            System.out.printf("\t[%s] - %s\n", res, name());
             if (ex != null) ex.printStackTrace();
             eyes.abortIfNotClosed();
         }
@@ -53,5 +46,9 @@ public class PDFTest extends Test {
 
     protected static boolean supports(File file) {
         return pattern.matcher(file.getName()).matches();
+    }
+
+    protected void setDpi(float dpi){
+        this.dpi_ =dpi;
     }
 }

--- a/src/lib/java/PDFTest.java
+++ b/src/lib/java/PDFTest.java
@@ -37,11 +37,16 @@ public class PDFTest extends Test {
             }
             result = eyes.close(false);
             printTestResults(result);
+            handleResultsDownload(result);
             document.close();
         } catch (IOException e) {
             ex = e;
             System.out.printf("Error closing test %s \nPath: %s \nReason: %s \n",e.getMessage());
 
+        } catch (Exception e) {
+            System.out.println("Oops, something went wrong!");
+            System.out.print(e);
+            e.printStackTrace();
         } finally {
             if (ex != null) ex.printStackTrace();
             eyes.abortIfNotClosed();

--- a/src/lib/java/PostscriptTest.java
+++ b/src/lib/java/PostscriptTest.java
@@ -1,4 +1,5 @@
 import com.applitools.eyes.Eyes;
+import com.applitools.eyes.TestResults;
 import org.ghost4j.document.DocumentException;
 import org.ghost4j.document.PSDocument;
 import org.ghost4j.renderer.RendererException;
@@ -28,7 +29,8 @@ public class PostscriptTest extends Test {
         renderer.setResolution(300);
         Exception ex = null;
         String res = null;
-
+        TestResults result=null;
+        
         try {
             document.load(file_);
             List<Image> images = renderer.render(document);
@@ -41,7 +43,7 @@ public class PostscriptTest extends Test {
                 eyes.checkImage(image, String.format("Page-%s", page++));
             }
 
-            eyes.close();
+            result = eyes.close(false);
         } catch (FileNotFoundException e) {
             res = "Error";
             ex = e;
@@ -59,7 +61,7 @@ public class PostscriptTest extends Test {
             res = "Error";
             e.printStackTrace();
         } finally {
-            System.out.printf("\t[%s] - %s\n", res, name());
+            printTestResults(result);
             if (ex != null) ex.printStackTrace();
             eyes.abortIfNotClosed();
         }

--- a/src/lib/java/SuiteBuilder.java
+++ b/src/lib/java/SuiteBuilder.java
@@ -1,7 +1,6 @@
 import com.applitools.eyes.BatchInfo;
 import com.applitools.eyes.RectangleSize;
 import org.apache.commons.io.comparator.NameFileComparator;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -80,8 +79,16 @@ public class SuiteBuilder {
         }
 
         if (curr.isFile()) {
-            if (PDFTest.supports(curr)) return new PDFTest(curr,appname_, pdfdpi_);
-            if (PostscriptTest.supports(curr)) return new PostscriptTest(curr, appname);
+            if (PDFTest.supports(curr)) {
+                PDFTest pdftest= new PDFTest(curr, appname_, pdfdpi_);
+                setEyesUtilitisParams(pdftest);
+                return pdftest;
+            }
+            if (PostscriptTest.supports(curr)) {
+                PostscriptTest postScriptest= new PostscriptTest(curr, appname);
+                setEyesUtilitisParams(postScriptest);
+                return postScriptest;
+            }
             return ImageStep.supports(curr) ? new ImageStep(curr) : null;
         }
 
@@ -96,11 +103,7 @@ public class SuiteBuilder {
             ITestable unit = build(file, appname, viewport, flatBatch);
             if (unit instanceof ImageStep) {
                 if (currTest == null) currTest = new Test(curr, appname, viewport);
-                currTest.setViewKey(viewKey_);
-                currTest.setDestinationFolder(destinationFolder_);
-                currTest.setDownloadDiffs(downloadDiffs_);
-                currTest.setGetImages(getImages_);
-                currTest.setGetGifs(getGifs_);
+                setEyesUtilitisParams(currTest);
                 ImageStep step = (ImageStep) unit;
                 if (step.hasRegionFile())
                     currTest.addSteps(step.getRegions());
@@ -144,5 +147,12 @@ public class SuiteBuilder {
 
         return currBatch;
     }
+    private void setEyesUtilitisParams(Test currTest){
+        currTest.setViewKey(viewKey_);
+        currTest.setDestinationFolder(destinationFolder_);
+        currTest.setDownloadDiffs(downloadDiffs_);
+        currTest.setGetImages(getImages_);
+        currTest.setGetGifs(getGifs_);
 
+    }
 }

--- a/src/lib/java/SuiteBuilder.java
+++ b/src/lib/java/SuiteBuilder.java
@@ -15,7 +15,7 @@ public class SuiteBuilder {
     private boolean downloadDiffs_;
     private boolean getImages_;
     private boolean getGifs_;
-    private float dpi_=300;
+    private float pdfdpi_;
 
     public SuiteBuilder(File rootFolder, String appname, RectangleSize viewport) {
         this.rootFolder_ = rootFolder;
@@ -27,13 +27,8 @@ public class SuiteBuilder {
         return build(rootFolder_, appname_, viewport_);
     }
 
-    public ITestable build(float dpi) throws IOException {
-
-        return build(rootFolder_, appname_, viewport_);
-    }
-
     public void setDpi(float dpi){
-        this.dpi_=dpi;
+        this.pdfdpi_ =dpi;
     }
     public void setViewKey(String viewKey) {
         this.viewKey_ = viewKey;
@@ -85,11 +80,7 @@ public class SuiteBuilder {
         }
 
         if (curr.isFile()) {
-            if (PDFTest.supports(curr)){
-                PDFTest pdfTest=new PDFTest(curr,appname_);
-                pdfTest.setDpi(dpi_);
-                return pdfTest;
-            }
+            if (PDFTest.supports(curr)) return new PDFTest(curr,appname_, pdfdpi_);
             if (PostscriptTest.supports(curr)) return new PostscriptTest(curr, appname);
             return ImageStep.supports(curr) ? new ImageStep(curr) : null;
         }

--- a/src/lib/java/SuiteBuilder.java
+++ b/src/lib/java/SuiteBuilder.java
@@ -15,6 +15,7 @@ public class SuiteBuilder {
     private boolean downloadDiffs_;
     private boolean getImages_;
     private boolean getGifs_;
+    private float dpi_=300;
 
     public SuiteBuilder(File rootFolder, String appname, RectangleSize viewport) {
         this.rootFolder_ = rootFolder;
@@ -26,6 +27,14 @@ public class SuiteBuilder {
         return build(rootFolder_, appname_, viewport_);
     }
 
+    public ITestable build(float dpi) throws IOException {
+
+        return build(rootFolder_, appname_, viewport_);
+    }
+
+    public void setDpi(float dpi){
+        this.dpi_=dpi;
+    }
     public void setViewKey(String viewKey) {
         this.viewKey_ = viewKey;
     }
@@ -76,7 +85,11 @@ public class SuiteBuilder {
         }
 
         if (curr.isFile()) {
-            if (PDFTest.supports(curr)) return new PDFTest(curr, appname);
+            if (PDFTest.supports(curr)){
+                PDFTest pdfTest=new PDFTest(curr,appname_);
+                pdfTest.setDpi(dpi_);
+                return pdfTest;
+            }
             if (PostscriptTest.supports(curr)) return new PostscriptTest(curr, appname);
             return ImageStep.supports(curr) ? new ImageStep(curr) : null;
         }

--- a/src/lib/java/Test.java
+++ b/src/lib/java/Test.java
@@ -72,8 +72,6 @@ public class Test extends TestUnit {
     private void handleResultsDownload(TestResults results) throws Exception {
         if (downloadDiffs_ || getGifs_ || getImages_) {
             if (viewKey_ == null) throw new RuntimeException("The view-key cannot be null");
-
-
             if (downloadDiffs_ && !results.isNew() && !results.isPassed())
                 new DownloadDiffs(results.getUrl(), destinationFolder_, viewKey_).run();
             if (getGifs_ && !results.isNew() && !results.isPassed())

--- a/src/lib/java/Test.java
+++ b/src/lib/java/Test.java
@@ -45,11 +45,7 @@ public class Test extends TestUnit {
         }
         try {
             TestResults result = eyes.close(false);
-
-            String res = result.isNew() ? "New" : (result.isPassed() ? "Passed" : "Failed");
-            System.out.printf("\t[%s] - %s\n", res, name());
-            if (!result.isPassed() && !result.isNew())
-                System.out.printf("\tResult url: %s\n", result.getUrl());
+            printTestResults(result);
             handleResultsDownload(result);
         } catch (EyesException e) {
             System.out.printf("Error closing test %s \nPath: %s \nReason: %s \n",
@@ -113,5 +109,14 @@ public class Test extends TestUnit {
 
     public void setGetGifs(boolean getGifs) {
         this.getGifs_ = getGifs;
+    }
+
+    protected void printTestResults(TestResults result){
+        String res = result.isNew() ? "New" : (result.isPassed() ? "Passed" : "Failed");
+        System.out.printf("\t[%s] - %s", res, name());
+        if (!result.isPassed() && !result.isNew())
+            System.out.printf("\tResult url: %s", result.getUrl());
+        System.out.println();
+
     }
 }

--- a/src/lib/java/Test.java
+++ b/src/lib/java/Test.java
@@ -16,11 +16,11 @@ public class Test extends TestUnit {
     protected final String appname_;
     protected RectangleSize viewportSize_;
     private Queue<ITestable> steps_;
-    private String viewKey_;
-    private String destinationFolder_;
-    private boolean downloadDiffs_;
-    private boolean getImages_;
-    private boolean getGifs_;
+    protected String viewKey_;
+    protected String destinationFolder_;
+    protected boolean downloadDiffs_;
+    protected boolean getImages_;
+    protected boolean getGifs_;
 
     protected Test(File file, String appname) {
         this(file, appname, null);
@@ -69,7 +69,7 @@ public class Test extends TestUnit {
         }
     }
 
-    private void handleResultsDownload(TestResults results) throws Exception {
+    protected void handleResultsDownload(TestResults results) throws Exception {
         if (downloadDiffs_ || getGifs_ || getImages_) {
             if (viewKey_ == null) throw new RuntimeException("The view-key cannot be null");
             if (downloadDiffs_ && !results.isNew() && !results.isPassed())

--- a/src/main/java/ImageTester.java
+++ b/src/main/java/ImageTester.java
@@ -78,6 +78,11 @@ public class ImageTester {
 
             SuiteBuilder builder = new SuiteBuilder(root, cmd.getOptionValue("a", "ImageTester"), viewport);
 
+            //DPI
+            if (cmd.hasOption("dpi")){
+                builder.setDpi(Float.valueOf(cmd.getOptionValue("dpi")));
+            }
+
             if (eyes_utils_enabled) {
                 if (cmd.hasOption("gd") || cmd.hasOption("gi") || cmd.hasOption("gg")) {
                     if (!cmd.hasOption("vk"))
@@ -211,6 +216,12 @@ public class ImageTester {
                 .desc("Set Host-app identifier for the screens under test")
                 .argName("app")
                 .build());
+        options.addOption(Option.builder("dpi")
+                .longOpt("DPI")
+                .desc("PDF conversion dots per inch parameter default value 300")
+                .hasArg().argName("Dpi")
+                .build());
+
 
         if (eyes_utils_enabled) {
             System.out.printf("%s is integrated, extra features are available. \n", eyes_utils);

--- a/src/main/java/ImageTester.java
+++ b/src/main/java/ImageTester.java
@@ -1,6 +1,7 @@
 import com.applitools.eyes.*;
 import org.apache.commons.cli.*;
 import org.apache.commons.io.FileUtils;
+import org.apache.log4j.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +20,8 @@ public class ImageTester {
         eyes_utils_enabled = new File(eyes_utils).exists();
         CommandLineParser parser = new DefaultParser();
         Options options = getOptions();
+
+        org.apache.log4j.Logger.getRootLogger().setLevel(Level.OFF);
 
         try {
             CommandLine cmd = parser.parse(options, args);
@@ -61,7 +64,6 @@ public class ImageTester {
             if (cmd.hasOption("os")) eyes.setHostOS(cmd.getOptionValue("os"));
             //host app
             if (cmd.hasOption("ap")) eyes.setHostApp(cmd.getOptionValue("ap"));
-
             // Set failed tests
             eyes.setSaveFailedTests(cmd.hasOption("as"));
             // Viewport size

--- a/src/main/java/ImageTester.java
+++ b/src/main/java/ImageTester.java
@@ -21,6 +21,7 @@ public class ImageTester {
         CommandLineParser parser = new DefaultParser();
         Options options = getOptions();
 
+        // This part disables log4j warnings
         org.apache.log4j.Logger.getRootLogger().setLevel(Level.OFF);
 
         try {
@@ -81,9 +82,8 @@ public class ImageTester {
             SuiteBuilder builder = new SuiteBuilder(root, cmd.getOptionValue("a", "ImageTester"), viewport);
 
             //DPI
-            if (cmd.hasOption("dpi")){
-                builder.setDpi(Float.valueOf(cmd.getOptionValue("dpi")));
-            }
+            builder.setDpi(Float.valueOf(cmd.getOptionValue("dpi", "300")));
+
 
             if (eyes_utils_enabled) {
                 if (cmd.hasOption("gd") || cmd.hasOption("gi") || cmd.hasOption("gg")) {
@@ -218,8 +218,8 @@ public class ImageTester {
                 .desc("Set Host-app identifier for the screens under test")
                 .argName("app")
                 .build());
-        options.addOption(Option.builder("dpi")
-                .longOpt("DPI")
+        options.addOption(Option.builder("di")
+                .longOpt("dpi")
                 .desc("PDF conversion dots per inch parameter default value 300")
                 .hasArg().argName("Dpi")
                 .build());

--- a/src/main/java/ImageTester.java
+++ b/src/main/java/ImageTester.java
@@ -210,12 +210,14 @@ public class ImageTester {
         options.addOption(Option.builder("os")
                 .longOpt("hostOs")
                 .desc("Set OS identifier for the screens under test")
+                .hasArg()
                 .argName("os")
                 .build());
 
         options.addOption(Option.builder("ap")
                 .longOpt("hostApp")
                 .desc("Set Host-app identifier for the screens under test")
+                .hasArg()
                 .argName("app")
                 .build());
         options.addOption(Option.builder("di")


### PR DESCRIPTION
Adding the option for specifying the DPI as parameter for PDF tests.
This parameter fix some bugs for example:
1) Stream truncated! (Block truncated)]
2) Java heap space - it simply allows to reduce the converted image
size.

In addition this commit includes a standard function for printing the
test result to console.

Last but not least in PDF test, the conversion process of the pdf into
image got shorter